### PR TITLE
I've modified the ESPHome configuration in `mailbox.yaml` to enhance …

### DIFF
--- a/mailbox.yaml
+++ b/mailbox.yaml
@@ -24,7 +24,7 @@ external_components:
 deep_sleep:
   id: deep_sleep_1
   wakeup_pin: GPIO2
-  run_duration: 60s  # Don't run at all, we'll use external wake up
+  run_duration: 30s  # Max run duration before forced sleep
   sleep_duration: 24h  # Sleep until external wake up
   
 
@@ -59,6 +59,7 @@ binary_sensor:
           color: BLUE
           speed: 0
           count: 0          
+      - deep_sleep.enter: deep_sleep_1
 
 # Fingerprint sensor configuration
 fingerprint_grow:
@@ -85,12 +86,14 @@ fingerprint_grow:
         speed: 50
         color: RED
         count: 2
+    - deep_sleep.enter: deep_sleep_1
   on_finger_scan_unmatched:
     - fingerprint_grow.aura_led_control:
         state: FLASHING
         speed: 25
         color: RED
         count: 2
+    - deep_sleep.enter: deep_sleep_1
   on_enrollment_done :
     - lambda: |-
         ESP_LOGI("main", "Fingerprint enrolled successfully!");


### PR DESCRIPTION
…battery conservation by consistently putting the device to sleep.

Key changes:
- I updated the global `deep_sleep` component's `run_duration` to 30 seconds. This ensures the device doesn't stay active for more than 30 seconds after waking up, unless a flow explicitly keeps it awake longer (which is not the case here).
- I added `deep_sleep.enter` actions to the following event triggers:
    - `on_finger_scan_invalid`: Device now sleeps after an invalid fingerprint scan.
    - `on_finger_scan_unmatched`: Device now sleeps after an unmatched fingerprint scan.
    - `on_release` for the `boot_button`: Device now sleeps after the boot button is released (which is used for toggling learning mode).

These changes ensure that all primary user interaction flows and error states result in the device returning to a low-power deep sleep state, aligning with the goal of preserving battery life. The existing `sleep_duration` of 24h (or until `wakeup_pin` is triggered) remains, meaning after the 30s active window or specific actions, it will sleep for an extended period.